### PR TITLE
Style update

### DIFF
--- a/api/controllers/eventsController.js
+++ b/api/controllers/eventsController.js
@@ -1,11 +1,9 @@
-﻿const eventList = require('../models/eventModels')
+﻿const getEventList = require('../models/eventModels')
 
 const getRecentAndUpcomingEvents = (request, response) => {
-  eventList(
-    function (data) {
-      response.json(data);
-    }
-  )
+
+  getEventList().then(data => response.json(data))
+
 }
 
 module.exports = {getRecentAndUpcomingEvents}

--- a/api/controllers/eventsController.js
+++ b/api/controllers/eventsController.js
@@ -1,9 +1,5 @@
 ﻿const getEventList = require('../models/eventModels')
 
-const getRecentAndUpcomingEvents = (request, response) => {
-
-  getEventList().then(data => response.json(data))
-
-}
+const getRecentAndUpcomingEvents = (request, response) => getEventList().then(data => response.json(data))
 
 module.exports = {getRecentAndUpcomingEvents}

--- a/api/controllers/eventsController.js
+++ b/api/controllers/eventsController.js
@@ -1,13 +1,11 @@
-﻿'use strict';
+﻿const eventList = require('../models/eventModels')
 
-var eventList = require('../models/eventModels'); //importing model
+const getRecentAndUpcomingEvents = (request, response) => {
+  eventList(
+    function (data) {
+      response.json(data);
+    }
+  )
+}
 
-exports.getRecentAndUpcomingEvents = function (request, response)
-{
-    eventList(
-        function (data)
-        {
-            response.json(data);
-        }
-    );
-};
+module.exports = {getRecentAndUpcomingEvents}

--- a/api/models/eventModels.js
+++ b/api/models/eventModels.js
@@ -13,14 +13,6 @@ const event = (title = '', location = '', startDate, endDate) => (
   }
 )
 
-const getTestEventList =  (callback) => {
-  
-  const testEvent1 = event("Test Event 1", "Test Location 1", '01/01/2017 14:00', '01/01/2017 16:00')
-  const testEvent2 = event("Test Event 2", "Test Location 2", '01/15/2017 14:00', '01/15/2017 16:00')
-
-  callback(undefined, [testEvent1,testEvent2])
-}
-
 const iCalToEvents = (iCalData) => {
 
   const jCal = iCal.parse(iCalData);
@@ -59,7 +51,6 @@ const getEventListRemoteProductionICal = () => {
 
 const getEventList = () => {
    
-    //getTestEventList()
     //getEventListFromLocalTestICal()
     //getEventListRemoteTestICal()
     return getEventListRemoteProductionICal()

--- a/api/models/eventModels.js
+++ b/api/models/eventModels.js
@@ -1,16 +1,14 @@
-﻿const {testICalURL, testICalLocalPath, productionICalURL} = require('../../data/endpoints')
+﻿const moment = require('moment')
+const {testICalURL, testICalLocalPath, productionICalURL} = require('../../data/endpoints')
 
-var event = function (title, location, startDate, endDate)
-{
-    var moment = require('moment');
-
-    return {
-        title: title,
-        location: location,
-        startDate: moment(startDate).format(),
-        endDate: moment(endDate).format(),
-    };
-};
+const event = (title = '', location = '', startDate, endDate) => (
+  {
+    title,
+    location,
+    startDate: moment(startDate).format(),
+    endDate: moment(endDate).format()
+  }
+)
 
 var getTestEventList = function (callback)
 {

--- a/api/models/eventModels.js
+++ b/api/models/eventModels.js
@@ -33,29 +33,16 @@ const iCalToEvents = (iCalData) => {
     jCalEvent.getFirstPropertyValue("dtend")
   ))
   
-  return eventList;
+  return eventList
 }
 
 const getEventListFromLocalTestICal = (callback) => {
     
-  var iCalendarData = fs.readFile(
-      testICalLocalPath,
-      'utf8',
-      function (error, data)
-      {
-          if (error)
-          {
-              callback(error, null);
-          }
-          else
-          {
-              var eventList = iCalToEvents(data);
-
-              callback(undefined, eventList);
-          }
-      }
-  );
-};
+  fs.readFile(testICalLocalPath, 'utf8', (error, data) => {
+    data ? callback(undefined, iCalToEvents(data)) : callback(error, undefined)
+  })
+  
+}
 
 var getEventListRemoteTestICal = function (callback)
 {

--- a/api/models/eventModels.js
+++ b/api/models/eventModels.js
@@ -10,7 +10,7 @@ const event = (title = '', location = '', startDate, endDate) => (
   }
 )
 
-var getTestEventList = function (callback)
+const getTestEventList = function (callback)
 {
     var eventList = [];
 
@@ -22,7 +22,7 @@ var getTestEventList = function (callback)
 
     eventList.push(testEvent2);
 
-    callback(null, eventList);
+    callback(eventList);
 
 };
 

--- a/api/models/eventModels.js
+++ b/api/models/eventModels.js
@@ -1,7 +1,4 @@
-﻿
-var testICalURL = "https://calendar.google.com/calendar/ical/matthewbierman.com_qmsnneuuh1k6btlqli2ina82s4%40group.calendar.google.com/public/basic.ics"
-var testICalLocalPath = ".\\data\\testCalendar.ics"
-var productionICalURL = "https://calendar.google.com/calendar/ical/qccoders%40gmail.com/public/basic.ics";
+﻿const {testICalURL, testICalLocalPath, productionICalURL} = require('../../data/endpoints')
 
 var event = function (title, location, startDate, endDate)
 {

--- a/api/models/eventModels.js
+++ b/api/models/eventModels.js
@@ -37,27 +37,17 @@ const getEventListFromLocalTestICal = () => {
 
 }
 
-const getEventListRemoteTestICal = () => {
-    
-  return axios.get(testICalURL)
+const getEventListRemoteTestICal = () => axios.get(testICalURL)
 
-}
+const getEventListRemoteProductionICal = () => axios.get(productionICalURL, {responseType: 'text'})
 
-const getEventListRemoteProductionICal = () => {
-
-  return axios.get(productionICalURL, {responseType: 'text'})
-
-}
-
-const getEventList = () => {
+const getEventList = () =>
    
     //getEventListFromLocalTestICal()
     //getEventListRemoteTestICal()
-    return getEventListRemoteProductionICal()
+    getEventListRemoteProductionICal()
     .then(res => iCalToEvents(res.data))
     .catch(e => console.log(e))
-
-}
 
 module.exports = getEventList;
 

--- a/api/models/eventModels.js
+++ b/api/models/eventModels.js
@@ -17,7 +17,7 @@ const getTestEventList =  (callback) => {
   const testEvent1 = event("Test Event 1", "Test Location 1", '01/01/2017 14:00', '01/01/2017 16:00')
   const testEvent2 = event("Test Event 2", "Test Location 2", '01/15/2017 14:00', '01/15/2017 16:00')
 
-  callback([testEvent1,testEvent2])
+  callback(undefined, [testEvent1,testEvent2])
 }
 
 const iCalToEvents = (iCalData) => {
@@ -51,7 +51,7 @@ const getEventListFromLocalTestICal = (callback) => {
           {
               var eventList = iCalToEvents(data);
 
-              callback(null, eventList);
+              callback(undefined, eventList);
           }
       }
   );
@@ -74,7 +74,7 @@ var getEventListRemoteTestICal = function (callback)
         {
             var eventList = iCalToEvents(body);
 
-            callback(null, eventList);
+            callback(undefined, eventList);
         }
     });
 };
@@ -96,7 +96,7 @@ var getEventListRemoteProductionICal = function (callback)
         {
             var eventList = iCalToEvents(body);
 
-            callback(null, eventList);
+            callback(undefined, eventList);
         }
     });
 };

--- a/api/models/eventModels.js
+++ b/api/models/eventModels.js
@@ -24,8 +24,8 @@ const getTestEventList =  (callback) => {
 const iCalToEvents = (iCalData) => {
 
   const jCal = iCal.parse(iCalData);
-  const {getAllSubcomponents} = new iCal.Component(jCal);
-  const jCalEvents = getAllSubcomponents("vevent");
+  const comp = new iCal.Component(jCal);
+  const jCalEvents = comp.getAllSubcomponents("vevent");
 
   const eventList = jCalEvents.map(jCalEvent => event(
     jCalEvent.getFirstPropertyValue("summary"),
@@ -37,7 +37,7 @@ const iCalToEvents = (iCalData) => {
   return eventList
 }
 
-const getEventListFromLocalTestICal = (callback) => {
+const getEventListFromLocalTestICal = () => {
     
   fs.readFile(testICalLocalPath, 'utf8', (error, data) => {
     data ? callback(undefined, iCalToEvents(data)) : callback(error, undefined)
@@ -45,53 +45,26 @@ const getEventListFromLocalTestICal = (callback) => {
 
 }
 
-const getEventListRemoteTestICal = (callback) => {
+const getEventListRemoteTestICal = () => {
     
-    axios.get(testICalURL)
-    .then(res => callback(undefined, iCalToEvents(res.data.body)))
-    .catch(e => callback(error, undefined))
+  return axios.get(testICalURL)
 
 }
 
-var getEventListRemoteProductionICal = function (callback)
-{
-    var request = require('request');
-    request.get(productionICalURL, function (error, response, body)
-    {
-        if (error)
-        {
-            callback(error, null);
-        }
-        else if (response.statusCode != 200)
-        {
-            callback("yeah, I don't know, jp?", null);
-        }
-        else
-        {
-            var eventList = iCalToEvents(body);
+const getEventListRemoteProductionICal = () => {
 
-            callback(undefined, eventList);
-        }
-    });
-};
+  return axios.get(productionICalURL, {responseType: 'text'})
 
-var getEventList = function (callback)
-{
-    var async = require('async');
+}
 
-    var asyncTasks = [];
-
-    //asyncTasks.push(getTestEventList);
-    //asyncTasks.push(getEventListFromLocalTestICal);
-    //asyncTasks.push(getEventListRemoteTestICal);
-    asyncTasks.push(getEventListRemoteProductionICal);
-
-
-    async.parallel(asyncTasks, function (error, data)
-    {
-        var eventList = [].concat.apply([], data); //flatten arrays
-        callback(eventList);
-    });
+const getEventList = () => {
+   
+    //getTestEventList()
+    //getEventListFromLocalTestICal()
+    //getEventListRemoteTestICal()
+    return getEventListRemoteProductionICal()
+    .then(res => iCalToEvents(res.data))
+    .catch(e => console.log(e))
 
 }
 

--- a/api/models/eventModels.js
+++ b/api/models/eventModels.js
@@ -1,6 +1,7 @@
 ﻿const fs = require('fs');
 const iCal = require('ical.js')
 const moment = require('moment')
+const axios = require('axios');
 const {testICalURL, testICalLocalPath, productionICalURL} = require('../../data/endpoints')
 
 const event = (title = '', location = '', startDate, endDate) => (
@@ -41,30 +42,16 @@ const getEventListFromLocalTestICal = (callback) => {
   fs.readFile(testICalLocalPath, 'utf8', (error, data) => {
     data ? callback(undefined, iCalToEvents(data)) : callback(error, undefined)
   })
-  
+
 }
 
-var getEventListRemoteTestICal = function (callback)
-{
-    var request = require('request');
-    request.get(testICalURL, function (error, response, body)
-    {
-        if (error)
-        {
-            callback(error, null);
-        }
-        else if (response.statusCode != 200)
-        {
-            callback("yeah, I don't know, jp?", null);
-        }
-        else
-        {
-            var eventList = iCalToEvents(body);
+const getEventListRemoteTestICal = (callback) => {
+    
+    axios.get(testICalURL)
+    .then(res => callback(undefined, iCalToEvents(res.data.body)))
+    .catch(e => callback(error, undefined))
 
-            callback(undefined, eventList);
-        }
-    });
-};
+}
 
 var getEventListRemoteProductionICal = function (callback)
 {

--- a/api/routes/eventRoutes.js
+++ b/api/routes/eventRoutes.js
@@ -1,11 +1,3 @@
-﻿'use strict';
+﻿const events = require('../controllers/eventsController')
 
-module.exports = function (app)
-{
-    var events = require('../controllers/eventsController');
-
-    // events Routes
-    app.route('/events')
-        .get(events.getRecentAndUpcomingEvents)
- 
-};
+module.exports = (app) => app.route('/events').get(events.getRecentAndUpcomingEvents)

--- a/data/endpoints.js
+++ b/data/endpoints.js
@@ -1,0 +1,5 @@
+module.exports = Object.freeze({
+  testICalURL: "https://calendar.google.com/calendar/ical/matthewbierman.com_qmsnneuuh1k6btlqli2ina82s4%40group.calendar.google.com/public/basic.ics",
+  testICalLocalPath: "./data/testCalendar.ics",
+  productionICalURL: "https://calendar.google.com/calendar/ical/qccoders%40gmail.com/public/basic.ics"
+})

--- a/data/endpoints.js
+++ b/data/endpoints.js
@@ -1,5 +1,5 @@
 module.exports = Object.freeze({
   testICalURL: "https://calendar.google.com/calendar/ical/matthewbierman.com_qmsnneuuh1k6btlqli2ina82s4%40group.calendar.google.com/public/basic.ics",
-  testICalLocalPath: "./data/testCalendar.ics",
+  testICalLocalPath: "./testCalendar.ics",
   productionICalURL: "https://calendar.google.com/calendar/ical/qccoders%40gmail.com/public/basic.ics"
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,31 +13,10 @@
         "negotiator": "0.6.1"
       }
     },
-    "ajv": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
-      }
-    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
       "version": "2.5.0",
@@ -47,54 +26,13 @@
         "lodash": "4.17.4"
       }
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
+    "axios": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.0.tgz",
+      "integrity": "sha1-fadHkW24A/dhZR1gkdcIeJuVPGo=",
       "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
+        "follow-redirects": "1.2.5",
+        "is-buffer": "1.1.5"
       }
     },
     "content-disposition": {
@@ -117,37 +55,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
@@ -155,11 +62,6 @@
       "requires": {
         "ms": "2.0.0"
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.1",
@@ -170,15 +72,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -235,21 +128,6 @@
         "vary": "1.1.1"
       }
     },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
-    },
     "finalhandler": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.5.tgz",
@@ -264,19 +142,22 @@
         "unpipe": "1.0.0"
       }
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+    "follow-redirects": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
+      "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "debug": "2.6.9"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "forwarded": {
@@ -289,44 +170,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
       "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "requires": {
-        "ajv": "5.2.2",
-        "har-schema": "2.0.0"
-      }
-    },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.0.2"
-      }
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-    },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
@@ -336,16 +179,6 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
       }
     },
     "ical.js": {
@@ -363,60 +196,10 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
       "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "lodash": {
       "version": "4.17.4",
@@ -471,11 +254,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -494,11 +272,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "proxy-addr": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
@@ -507,11 +280,6 @@
         "forwarded": "0.1.2",
         "ipaddr.js": "1.4.0"
       }
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
       "version": "6.5.0",
@@ -522,47 +290,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-    },
-    "request": {
-      "version": "2.82.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.82.0.tgz",
-      "integrity": "sha512-/QWqfmyTfQ4OYs6EhB1h2wQsX9ZxbuNePCvCm0Mdz/mxw73mjdg0D4QdIl0TQBFs35CZmMXLjk0iCGK395CUDg==",
-      "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
-        }
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "send": {
       "version": "0.15.4",
@@ -600,60 +327,10 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
-    "sntp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      }
-    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-    },
-    "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "requires": {
-        "punycode": "1.4.1"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
     },
     "type-is": {
       "version": "1.6.15",
@@ -674,25 +351,10 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
     },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
       "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,6 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
-    "async": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
     "axios": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.0.tgz",
@@ -200,11 +192,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "async": "^2.5.0",
+    "axios": "^0.17.0",
     "express": "^4.15.4",
     "ical.js": "^1.2.2",
-    "moment": "^2.18.1",
-    "request": "^2.82.0"
+    "moment": "^2.18.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "async": "^2.5.0",
     "axios": "^0.17.0",
     "express": "^4.15.4",
     "ical.js": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": {
     "name": "mbierman"
   },
+  "scripts": {
+    "start": "node server.js"
+  },
   "dependencies": {
     "async": "^2.5.0",
     "express": "^4.15.4",


### PR DESCRIPTION
Favoring promises over callbacks removed a lot of code. Also, a combination of arrow function, implicit returns, and a bit of functional style programming reduced the complexity, increased readability, and will make testing simpler.  After running `npm i` you can now run `npm start` to run the app. 

All `var` declarations were changed to `const`. `let` is also available, but I don't think I used that as nothing needed reassigning. 